### PR TITLE
Fix deprecated proptypes warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "unexpected-react": "^3.4.0"
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-truncate": "^2.0.5"
   }
 }

--- a/src/ShowMore.js
+++ b/src/ShowMore.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import Truncate from 'react-truncate';
 
 class ShowMore extends Component {


### PR DESCRIPTION
React.PropTypes deprecated in new versions of React in favor of prop-types module

Deprecation: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html