### PR TITLE
Add `width` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ class Foo extends Component {
 | more | string, React node | 'Show more' | The text to display in the anchor element to show more. | `'Show more'`, `<span>Show more</span>`
 | less | string, React node | 'Show less' | The text to display in the anchor element to show less. | `'Show less'`, `<span>Show less</span>`
 | anchorClass | string | '' | Class name(s) to add to the anchor elements. | `'my-anchor-class'`, `'class-1 class-2'`
+| width | number | 0 | If not 0, the calculation of the content will be based on this number. | ``
 
 ## Developing
 Install development dependencies

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "prop-types": "^15.5.10"
   },
   "dependencies": {
-    "react-truncate": "^2.3.0"
+    "react-truncate": "^2.4.0"
   }
 }

--- a/src/ShowMore.js
+++ b/src/ShowMore.js
@@ -15,7 +15,8 @@ class ShowMore extends Component {
         lines: PropTypes.number,
         more: PropTypes.node,
         less: PropTypes.node,
-        anchorClass: PropTypes.string
+        anchorClass: PropTypes.string,
+        width: PropTypes.number
     }
 
     state = {
@@ -45,7 +46,8 @@ class ShowMore extends Component {
             more,
             less,
             lines,
-            anchorClass
+            anchorClass,
+            width
         } = this.props;
 
         const {
@@ -56,6 +58,7 @@ class ShowMore extends Component {
         return (
             <div>
                 <Truncate
+                    width={width}
                     lines={!expanded && lines}
                     ellipsis={(
                         <span>... <a href='#' className={anchorClass} onClick={this.toggleLines}>{more}</a></span>

--- a/src/ShowMore.js
+++ b/src/ShowMore.js
@@ -7,7 +7,8 @@ class ShowMore extends Component {
         lines: 3,
         more: 'Show more',
         less: 'Show less',
-        anchorClass: ''
+        anchorClass: '',
+        width: 0
     }
 
     static propTypes = {


### PR DESCRIPTION
react truncate has a new property `width`, patch to allow props to pass through to `react-truncate`, also updated `react-truncate`