### PR TITLE
Moving onClick event to React node

### DIFF
--- a/src/ShowMore.js
+++ b/src/ShowMore.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
 
@@ -53,19 +53,22 @@ class ShowMore extends Component {
             truncated
         } = this.state;
 
+        const ancorElementMore = isValidElement(more) ? React.cloneElement(more, { onClick : this.toggleLines }) : <a href='#' className={anchorClass} onClick={this.toggleLines}>{more}</a>;
+        const ancorElementLess = isValidElement(less) ? React.cloneElement(less, { onClick : this.toggleLines }) : <a href='#' className={anchorClass} onClick={this.toggleLines}>{less}</a>;
+
         return (
             <div>
                 <Truncate
                     lines={!expanded && lines}
                     ellipsis={(
-                        <span>... <a href='#' className={anchorClass} onClick={this.toggleLines}>{more}</a></span>
+                        <span><span>...</span> { ancorElementMore }</span>
                     )}
                     onTruncate={this.handleTruncate}
                 >
                     {children}
                 </Truncate>
                 {!truncated && expanded && (
-                    <span> <a href='#' className={anchorClass} onClick={this.toggleLines}>{less}</a></span>
+                    <span> { ancorElementLess }</span>
                 )}
             </div>
         );

--- a/src/ShowMore.js
+++ b/src/ShowMore.js
@@ -53,22 +53,22 @@ class ShowMore extends Component {
             truncated
         } = this.state;
 
-        const ancorElementMore = isValidElement(more) ? React.cloneElement(more, { onClick : this.toggleLines }) : <a href='#' className={anchorClass} onClick={this.toggleLines}>{more}</a>;
-        const ancorElementLess = isValidElement(less) ? React.cloneElement(less, { onClick : this.toggleLines }) : <a href='#' className={anchorClass} onClick={this.toggleLines}>{less}</a>;
+        const anchorElementMore = isValidElement(more) ? React.cloneElement(more, { onClick : this.toggleLines }) : <a href='#' className={anchorClass} onClick={this.toggleLines}>{more}</a>;
+        const anchorElementLess = isValidElement(less) ? React.cloneElement(less, { onClick : this.toggleLines }) : <a href='#' className={anchorClass} onClick={this.toggleLines}>{less}</a>;
 
         return (
             <div>
                 <Truncate
                     lines={!expanded && lines}
                     ellipsis={(
-                        <span><span>...</span> { ancorElementMore }</span>
+                        <span><span>...</span> { anchorElementMore }</span>
                     )}
                     onTruncate={this.handleTruncate}
                 >
                     {children}
                 </Truncate>
                 {!truncated && expanded && (
-                    <span> { ancorElementLess }</span>
+                    <span> { anchorElementLess }</span>
                 )}
             </div>
         );


### PR DESCRIPTION
When you supply a React node, I'd like to move the onClick event to the React node instead of the surrounding span element.

In my case I wanted to center a small button below the text in the center of the parent container that holds the text. Moving the onClick event makes sure you need to click the button (and not the span element which is 100% width of the parent container). 

Before this change you could click anywhere to the left or right of the button instead of straight on it.